### PR TITLE
rich

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -37,6 +37,25 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "commonmark"
+version = "0.9.1"
+description = "Python parser for the CommonMark Markdown spec"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.extras]
+test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
+
+[[package]]
 name = "flake8"
 version = "3.8.4"
 description = "the modular source code checker: pep8 pyflakes and co"
@@ -119,12 +138,37 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
+name = "pygments"
+version = "2.7.3"
+description = "Pygments is a syntax highlighting package written in Python."
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "regex"
 version = "2020.11.13"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "rich"
+version = "9.5.1"
+description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
+category = "main"
+optional = false
+python-versions = ">=3.6,<4.0"
+
+[package.dependencies]
+colorama = ">=0.4.0,<0.5.0"
+commonmark = ">=0.9.0,<0.10.0"
+pygments = ">=2.6.0,<3.0.0"
+typing-extensions = ">=3.7.4,<4.0.0"
+
+[package.extras]
+jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
 
 [[package]]
 name = "toml"
@@ -146,14 +190,14 @@ python-versions = "*"
 name = "typing-extensions"
 version = "3.7.4.3"
 description = "Backported and Experimental Type Hints for Python 3.5+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = "*"
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "1d12e3da4ea47705b4f158edd334540d34f7077c6402da9ecdb0385e994eb848"
+content-hash = "4568043922cb934b2bb7af56253cdeb2071ef4771cc7c9cfc315733d6caa5794"
 
 [metadata.files]
 appdirs = [
@@ -166,6 +210,14 @@ black = [
 click = [
     {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
     {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
+]
+colorama = [
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+commonmark = [
+    {file = "commonmark-0.9.1-py2.py3-none-any.whl", hash = "sha256:da2f38c92590f83de410ba1a3cbceafbc74fee9def35f9251ba9a971d6d66fd9"},
+    {file = "commonmark-0.9.1.tar.gz", hash = "sha256:452f9dc859be7f06631ddcb328b6919c67984aca654e5fefb3914d54691aed60"},
 ]
 flake8 = [
     {file = "flake8-3.8.4-py2.py3-none-any.whl", hash = "sha256:749dbbd6bfd0cf1318af27bf97a14e28e5ff548ef8e5b1566ccfb25a11e7c839"},
@@ -211,6 +263,10 @@ pyflakes = [
     {file = "pyflakes-2.2.0-py2.py3-none-any.whl", hash = "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92"},
     {file = "pyflakes-2.2.0.tar.gz", hash = "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"},
 ]
+pygments = [
+    {file = "Pygments-2.7.3-py3-none-any.whl", hash = "sha256:f275b6c0909e5dafd2d6269a656aa90fa58ebf4a74f8fcf9053195d226b24a08"},
+    {file = "Pygments-2.7.3.tar.gz", hash = "sha256:ccf3acacf3782cbed4a989426012f1c535c9a90d3a7fc3f16d231b9372d2b716"},
+]
 regex = [
     {file = "regex-2020.11.13-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8b882a78c320478b12ff024e81dc7d43c1462aa4a3341c754ee65d857a521f85"},
     {file = "regex-2020.11.13-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a63f1a07932c9686d2d416fb295ec2c01ab246e89b4d58e5fa468089cab44b70"},
@@ -253,6 +309,10 @@ regex = [
     {file = "regex-2020.11.13-cp39-cp39-win32.whl", hash = "sha256:f8f295db00ef5f8bae530fc39af0b40486ca6068733fb860b42115052206466f"},
     {file = "regex-2020.11.13-cp39-cp39-win_amd64.whl", hash = "sha256:a15f64ae3a027b64496a71ab1f722355e570c3fac5ba2801cafce846bf5af01d"},
     {file = "regex-2020.11.13.tar.gz", hash = "sha256:83d6b356e116ca119db8e7c6fc2983289d87b27b3fac238cfe5dca529d884562"},
+]
+rich = [
+    {file = "rich-9.5.1-py3-none-any.whl", hash = "sha256:0f4359df97670c1981599690458c4c9ede02c56f59ae3a648b7154cdba21b0cc"},
+    {file = "rich-9.5.1.tar.gz", hash = "sha256:8b937e2d2c4ff9dcfda8a5910a8cd384bd30f50ec92346d616f62065c662df5f"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ authors = ["Samuel Searles-Bryant <devel@samueljsb.co.uk>"]
 [tool.poetry.dependencies]
 python = "^3.8"
 click = "^7.1.2"
+rich = "^9.5.1"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"

--- a/qaz/cli.py
+++ b/qaz/cli.py
@@ -7,7 +7,7 @@ import click
 from qaz import config
 from qaz.utils import output, shell
 
-from .module import DependenciesMissing, Module
+from .module import DependenciesMissing, Module, NotInstalled
 from .modules import all_modules, get_modules
 
 
@@ -58,7 +58,10 @@ def install(modules: Tuple[str]):
     for module in _get_modules(modules):
         try:
             module.install()
-        except (DependenciesMissing, CalledProcessError) as exc:
+        except DependenciesMissing as exc:
+            output.error(str(exc))
+            raise click.Abort()
+        except CalledProcessError as exc:
             raise click.ClickException(str(exc))
 
 
@@ -77,7 +80,10 @@ def upgrade(modules: Iterable[str], upgrade_all: bool):
     for module in _get_modules(modules):
         try:
             module.upgrade()
-        except (DependenciesMissing, CalledProcessError) as exc:
+        except (DependenciesMissing, NotInstalled) as exc:
+            output.error(str(exc))
+            raise click.Abort()
+        except CalledProcessError as exc:
             raise click.ClickException(str(exc))
 
 

--- a/qaz/cli.py
+++ b/qaz/cli.py
@@ -24,19 +24,17 @@ def setup(root_dir: str):
     """
     Install this tool and the basics.
     """
-    output.message("Installing qaz...")
+    with output.status("Installing qaz...", "Installed qaz 🎉"):
 
-    # Create config
-    config.create_new_config_file(root_dir)
+        # Create config
+        config.create_new_config_file(root_dir)
 
-    # Create installed dir
-    zshrc_dir = Path.home().joinpath(".zshrc.d")
-    zshrc_dir.mkdir(exist_ok=True)
+        # Create installed dir
+        zshrc_dir = Path.home().joinpath(".zshrc.d")
+        zshrc_dir.mkdir(exist_ok=True)
 
-    ALREADY_INSTALLED = ("asdf", "python", "poetry")
-    install(ALREADY_INSTALLED)
-
-    output.message("... qaz is installed.")
+        ALREADY_INSTALLED = ("asdf", "python", "poetry")
+        install(ALREADY_INSTALLED)
 
 
 @cli.command()
@@ -45,8 +43,10 @@ def update():
     Update this tool.
     """
     root_dir = config.get_root_dir()
-    shell.run(f"git -C {root_dir} pull")
-    shell.run("poetry install --remove-untracked", cwd=root_dir)
+
+    with output.status("Updating qaz...", "Updated qaz 🥳"):
+        shell.run(f"git -C {root_dir} pull")
+        shell.run("poetry install --remove-untracked", cwd=root_dir)
 
 
 @cli.command()
@@ -56,13 +56,16 @@ def install(modules: Tuple[str]):
     Install modules.
     """
     for module in _get_modules(modules):
-        try:
-            module.install()
-        except DependenciesMissing as exc:
-            output.error(str(exc))
-            raise click.Abort()
-        except CalledProcessError as exc:
-            raise click.ClickException(str(exc))
+        with output.status(
+            f"Installing {module.name}...", f"Installed {module.name} 🎉"
+        ):
+            try:
+                module.install()
+            except DependenciesMissing as exc:
+                output.error(str(exc))
+                raise click.Abort()
+            except CalledProcessError as exc:
+                raise click.ClickException(str(exc))
 
 
 @cli.command()
@@ -78,13 +81,14 @@ def upgrade(modules: Iterable[str], upgrade_all: bool):
         modules = [m.name for m in all_modules if config.is_module_installed(m.name)]
 
     for module in _get_modules(modules):
-        try:
-            module.upgrade()
-        except (DependenciesMissing, NotInstalled) as exc:
-            output.error(str(exc))
-            raise click.Abort()
-        except CalledProcessError as exc:
-            raise click.ClickException(str(exc))
+        with output.status(f"Upgrading {module.name}...", f"Upgraded {module.name} 🥳"):
+            try:
+                module.upgrade()
+            except (DependenciesMissing, NotInstalled) as exc:
+                output.error(str(exc))
+                raise click.Abort()
+            except CalledProcessError as exc:
+                raise click.ClickException(str(exc))
 
 
 def _get_modules(module_names: Iterable[str]) -> List[Module]:

--- a/qaz/cli.py
+++ b/qaz/cli.py
@@ -72,7 +72,7 @@ def upgrade(modules: Iterable[str], upgrade_all: bool):
     Upgrade modules.
     """
     if upgrade_all:
-        modules = config.get_installed_module_names()
+        modules = [m.name for m in all_modules if config.is_module_installed(m.name)]
 
     for module in _get_modules(modules):
         try:

--- a/qaz/module.py
+++ b/qaz/module.py
@@ -17,6 +17,10 @@ class DependenciesMissing(Exception):
         return f"Dependencies missing: {', '.join(self.dependencies)}."
 
 
+class NotInstalled(Exception):
+    pass
+
+
 class Module:
     # Attributes to overwrite
     name: str
@@ -65,8 +69,7 @@ class Module:
 
     def upgrade(self):
         if not self.is_installed:
-            output.error(f"Cannot upgrade: {self.name} is not installed")
-            return
+            raise NotInstalled(f"Cannot upgrade: {self.name} is not installed")
 
         output.message(f"Upgrading {self.name}...")
 

--- a/qaz/module.py
+++ b/qaz/module.py
@@ -3,7 +3,7 @@ from typing import Dict, List, Optional, Union
 
 from qaz import config
 from qaz.managers import code
-from qaz.utils import files, output, shell
+from qaz.utils import files, shell
 
 
 PathLike = Union[Path, str]
@@ -44,9 +44,7 @@ class Module:
         return super().__init_subclass__()
 
     def install(self):
-        output.message(f"Installing {self.name}...")
         if self.is_installed:
-            output.message(f"... {self.name} already installed!")
             return
 
         self._check_dependencies()
@@ -57,7 +55,6 @@ class Module:
         self._install_vscode_extensions()
 
         self.set_installed()
-        output.message(f"... {self.name} installed!")
 
     def install_action(self):
         """
@@ -71,16 +68,12 @@ class Module:
         if not self.is_installed:
             raise NotInstalled(f"Cannot upgrade: {self.name} is not installed")
 
-        output.message(f"Upgrading {self.name}...")
-
         self._check_dependencies()
 
         self._link_zshrc()
         self._create_symlinks()
         self._install_vscode_extensions()
         self.upgrade_action()
-
-        output.message(f"... {self.name} upgraded!")
 
     def upgrade_action(self):
         """
@@ -128,6 +121,4 @@ class Module:
         if not command or not self.vscode_extensions:
             return
 
-        output.message("Installing VS Code extensions...")
         code.install_extensions(self.vscode_extensions)
-        output.message("... VS Code extensions installed!")

--- a/qaz/modules/__init__.py
+++ b/qaz/modules/__init__.py
@@ -22,6 +22,10 @@ from .vscode import VSCode
 from .zsh import ZSH, OhMyZSH
 
 
+class ModuleNotFound(Exception):
+    pass
+
+
 modules: List[Module] = [
     ASDF(),
     Brew(),
@@ -78,5 +82,5 @@ def get_modules(module_names: Iterable[str]) -> List[Module]:
             missing.append(name)
 
     if missing:
-        raise ValueError(f"Modules not found with names: {missing}")
+        raise ModuleNotFound(f"Modules not found with names: {missing}")
     return found

--- a/qaz/modules/fonts.py
+++ b/qaz/modules/fonts.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 from qaz.modules.git import GitModule
@@ -21,6 +22,12 @@ class NerdFonts(GitModule):
             shell.run(f"{self.repo_path / 'install.sh'} {font_name}")
 
     def upgrade_action(self):
+        if sys.platform == "darwin":
+            # There are issues with case-insensitive filenames that prevent the repo
+            # from being pulled on macOS.
+            output.message("nerd-fonts cannot be upgraded on MacOS at the moment 😞")
+            return
+
         super().upgrade_action()
 
         for font_name in FONTS:

--- a/qaz/modules/fonts.py
+++ b/qaz/modules/fonts.py
@@ -18,14 +18,10 @@ class NerdFonts(GitModule):
         super().install_action()
 
         for font_name in FONTS:
-            output.message(f"... installing font: {font_name} ...")
             shell.run(f"{self.repo_path / 'install.sh'} {font_name}")
-            output.message(f"... ... {font_name} installed!")
 
     def upgrade_action(self):
         super().upgrade_action()
 
         for font_name in FONTS:
-            output.message(f"... installing font: {font_name} ...")
             shell.run(f"{self.repo_path / 'install.sh'} {font_name}")
-            output.message(f"... ... {font_name} installed!")

--- a/qaz/modules/vim.py
+++ b/qaz/modules/vim.py
@@ -12,8 +12,8 @@ class Vim(GitModule):
 
     def install_action(self):
         super().install_action()
-        shell.run("vim +PluginInstall +qall")
+        shell.run("vim +PluginInstall +qall", suppress_output=True)
 
     def upgrade_action(self):
         super().upgrade_action()
-        shell.run("vim +PluginInstall +qall")
+        shell.run("vim +PluginInstall +qall", suppress_output=True)

--- a/qaz/utils/output.py
+++ b/qaz/utils/output.py
@@ -1,3 +1,5 @@
+from contextlib import contextmanager
+
 import rich.console
 
 
@@ -14,3 +16,12 @@ def error(msg: str):
 
 def command(command: str):
     console.print(f"$ {command}", style="bold yellow", highlight=False)
+
+
+@contextmanager
+def status(status_msg: str, complete_msg: str = ""):
+    with console.status(status_msg):
+        yield
+
+    if complete_msg:
+        message(complete_msg)

--- a/qaz/utils/output.py
+++ b/qaz/utils/output.py
@@ -1,10 +1,6 @@
 import click
 
 
-def echo(msg: str):
-    click.echo(msg, err=True)
-
-
 def message(msg: str):
     click.secho(msg, bold=True, err=True)
 

--- a/qaz/utils/output.py
+++ b/qaz/utils/output.py
@@ -25,3 +25,7 @@ def status(status_msg: str, complete_msg: str = ""):
 
     if complete_msg:
         message(complete_msg)
+
+
+def out(msg: str):
+    console.out(msg, highlight=False)

--- a/qaz/utils/output.py
+++ b/qaz/utils/output.py
@@ -1,13 +1,16 @@
-import click
+import rich.console
+
+
+console = rich.console.Console()
 
 
 def message(msg: str):
-    click.secho(msg, bold=True, err=True)
+    console.print(msg, style="bold")
 
 
 def error(msg: str):
-    click.secho(msg, fg="red", bold=True, err=True)
+    console.print("[bold red]Error:[/bold red]", msg, highlight=False)
 
 
 def command(command: str):
-    click.secho(f"$ {command}", bold=True, fg="yellow", err=True)
+    console.print(f"$ {command}", style="bold yellow", highlight=False)

--- a/qaz/utils/shell.py
+++ b/qaz/utils/shell.py
@@ -11,9 +11,9 @@ def run(
     cwd: Optional[str] = None,
     allow_fail: bool = False,
     env: Dict[str, str] = None,
-    show: bool = False
+    log: bool = True
 ):
-    if show:
+    if log:
         output.command(command)
 
     process = subprocess.run(
@@ -21,14 +21,7 @@ def run(
         cwd=cwd,
         shell=True,
         env=os.environ.update(env if env else {}),
-        text=True,
-        capture_output=(not show),
     )
-
-    if not show and process.returncode != 0:
-        output.command(command)
-        output.echo(process.stderr)
-
     if not allow_fail:
         process.check_returncode()
 

--- a/qaz/utils/shell.py
+++ b/qaz/utils/shell.py
@@ -11,6 +11,7 @@ def run(
     cwd: Optional[str] = None,
     allow_fail: bool = False,
     env: Dict[str, str] = None,
+    suppress_output: bool = False
 ):
     output.command(command)
 
@@ -19,7 +20,23 @@ def run(
         cwd=cwd,
         shell=True,
         env=os.environ.update(env if env else {}),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
     )
+
+    if not suppress_output:
+        # Collect each line before trying to output.
+        # NOTE: this is necessary because rich.out doesn't handle printing each
+        # character one at a time without a newline at the end.
+        line = ""
+        for char in process.stdout:
+            if char == "\n":
+                output.out(line)
+                line = ""
+                continue
+            line += char
+
     if not allow_fail:
         process.check_returncode()
 

--- a/qaz/utils/shell.py
+++ b/qaz/utils/shell.py
@@ -11,10 +11,8 @@ def run(
     cwd: Optional[str] = None,
     allow_fail: bool = False,
     env: Dict[str, str] = None,
-    log: bool = True
 ):
-    if log:
-        output.command(command)
+    output.command(command)
 
     process = subprocess.run(
         command,


### PR DESCRIPTION
TODO: the password prompt is hidden by the status spinner. Can anything be done about that?

*****

- Fix a bug with upgrading all modules
- Revert "Hide shell command output when no error"
- Remove the option to not print a shell cmd
- Handle expected errors explicitly with an error message and abort
- Add rich
- Change output to use rich instead of click.echo
- Create a status context manager
- Pipe the output from subprocess calls to rich
- Use the status context manager rather than printing updates
- [vim] Silence noisy command
- Remove unnecessary output
- Handle invalid module names explicitly
