### PR TITLE
Dynamically determine zshrc file path when needed

### DIFF
--- a/qaz/module.py
+++ b/qaz/module.py
@@ -30,14 +30,9 @@ class Module:
     vscode_extensions: List[str] = list()
 
     # Internal attributes
-    _zshrc_path: Path
     _base_requires: Optional[List["Module"]] = None
 
     def __init__(self):
-        # .zshrc file
-        zshrc_fname = self.zshrc_file or f"{self.name.lower()}.zsh"
-        self._zshrc_path = config.get_root_dir() / "zshrc" / zshrc_fname
-
         # base requirements
         self.requires = self.requires + (self._base_requires or [])
 
@@ -103,9 +98,11 @@ class Module:
         """
         Create symlink from ~/.zshrc.d to the zshrc file for this module.
         """
-        if self._zshrc_path.exists():
+        zshrc_fname = self.zshrc_file or f"{self.name.lower()}.zsh"
+        zshrc_path = config.get_root_dir() / "zshrc" / zshrc_fname
+        if zshrc_path.exists():
             files.create_symlink(
-                self._zshrc_path,
+                zshrc_path,
                 Path.home() / ".zshrc.d",
             )
 


### PR DESCRIPTION
Prior to this change, we stored the zshrc filepath for a module in
__init__. This meant that the path was calculated at module
instantiation time, which is also import time. This meant the config
file was being loaded at import time, which caused errors when setting
up a new machine (since the config file does not yet exist)

This change moves the calculation of the zshrc filepath to the method
that needs it: there's no reason to store it on the object.
