### PR TITLE
cli errors

### DIFF
--- a/qaz/application/install.py
+++ b/qaz/application/install.py
@@ -31,7 +31,10 @@ def install_modules(module_names: Iterable[str]) -> None:
     """
     Install modules with names matching the given names.
 
-    Raises CannotInstallModule if a module cannot be installed.
+    Raises:
+        - ValueError if a module name is not recognised.
+        - CannotInstallModule if a module cannot be installed.
+
     """
     # Retrieve the modules to be installed.
     try:

--- a/qaz/application/upgrade.py
+++ b/qaz/application/upgrade.py
@@ -22,7 +22,10 @@ def upgrade_modules(module_names: Iterable[str]) -> None:
     """
     Upgrade modules with names matching the given names.
 
-    Raises CannotUpgradeModule if a module cannot be upgraded for any reason.
+    Raises:
+        - ValueError if a module name is not recognised.
+        - CannotUpgradeModule if a module cannot be upgraded for any reason.
+
     """
     # Retrieve the modules to be upgraded.
     try:

--- a/qaz/cli/_cli.py
+++ b/qaz/cli/_cli.py
@@ -49,7 +49,7 @@ def _install(ctx: click.Context, modules: Tuple[str]):
     try:
         install.install_modules(modules)
     except (install.CannotInstallModule, ValueError) as exc:
-        logger.exception(exc)
+        logger.error(exc)
         ctx.exit(1)
 
 
@@ -63,7 +63,7 @@ def _upgrade(ctx: click.Context, modules: Iterable[str]):
     try:
         upgrade.upgrade_modules(modules)
     except (upgrade.CannotUpgradeModule, ValueError) as exc:
-        logger.exception(exc)
+        logger.error(exc)
         ctx.exit(1)
 
 

--- a/qaz/cli/_cli.py
+++ b/qaz/cli/_cli.py
@@ -48,7 +48,7 @@ def _install(ctx: click.Context, modules: Tuple[str]):
     """
     try:
         install.install_modules(modules)
-    except install.CannotInstallModule as exc:
+    except (install.CannotInstallModule, ValueError) as exc:
         logger.exception(exc)
         ctx.exit(1)
 
@@ -62,7 +62,7 @@ def _upgrade(ctx: click.Context, modules: Iterable[str]):
     """
     try:
         upgrade.upgrade_modules(modules)
-    except upgrade.CannotUpgradeModule as exc:
+    except (upgrade.CannotUpgradeModule, ValueError) as exc:
         logger.exception(exc)
         ctx.exit(1)
 


### PR DESCRIPTION
- Document exceptions raise by install/upgrade commands correctly
- Catch `ValueError`s when module name incorrect
- Show tidier output when printing exceptions
