### PR TITLE
Move virtual env `venv` -> `.venv`

### DIFF
--- a/install
+++ b/install
@@ -41,15 +41,15 @@ message '... Poetry installed!'
 # Install management tool
 message "Installing qaz management tool..."
 cd $QAZ
-asdf exec python -m venv venv
-. venv/bin/activate
+asdf exec python -m venv .venv
+. .venv/bin/activate
 $HOME/.poetry/bin/poetry install --no-dev
-sudo ln -sf $QAZ/venv/bin/qaz /usr/local/bin
+sudo ln -sf $QAZ/.venv/bin/qaz /usr/local/bin
 message "... management tool installed!"
 
 # Run management tool to install basics
 mkdir -p $HOME/.config
-$QAZ/venv/bin/qaz setup $QAZ
+$QAZ/.venv/bin/qaz setup $QAZ
 
 # Install zsh and set as default shell
-$QAZ/venv/bin/qaz install zsh
+$QAZ/.venv/bin/qaz install zsh

--- a/qaz/application/update.py
+++ b/qaz/application/update.py
@@ -14,5 +14,4 @@ def update_qaz() -> None:
     shell.run(
         "poetry install --no-dev --remove-untracked",
         cwd=root_dir,
-        env=dict(VIRTUAL_ENV=str(root_dir / "venv")),
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ max-complexity = 10
 max-line-length = 88
 extend-ignore = E203, W503
 exclude =
-    venv
+    .venv
 
 [mypy]
 # Do not error when a third party has not defined typed definitions.


### PR DESCRIPTION
Prior to this change, the virtual environm,ent for this project was in
`venv`. However, Poetry picks up a local virtual environment from a
`.venv` directory.

This change switches to use the dotted path so Poetry will use it
correctly.
