### PR TITLE
[asdf] Sort versions manually

### DIFF
--- a/qaz/managers/asdf.py
+++ b/qaz/managers/asdf.py
@@ -1,3 +1,4 @@
+from distutils.version import StrictVersion
 from typing import List
 
 from . import shell
@@ -29,4 +30,10 @@ def _set_latest(plugin: str):
 
 
 def _get_installed_versions(plugin: str) -> List[str]:
-    return shell.capture(f"asdf list {plugin}").split()
+    versions = shell.capture(f"asdf list {plugin}").split()
+
+    # Sort the versions.
+    # This is necessary to ensure '3.10.0' is later than '3.1.0'.
+    versions.sort(key=StrictVersion)
+
+    return versions


### PR DESCRIPTION
Prior to this change, we could not set Python 3.10.0 as the global
version becasue it gets sorted higher in the list than 3.9.0.

This change sorts the version list. This gets us the versions in the
correct order.
