### PR TITLE
[VS Code] increase font size

### DIFF
--- a/configfiles/settings.json
+++ b/configfiles/settings.json
@@ -28,6 +28,7 @@
   },
   "editor.detectIndentation": false,
   "editor.fontFamily": "Hack Nerd Font, Menlo, Monaco, 'Courier New', monospace",
+  "editor.fontSize": 13,
   "editor.formatOnSave": true,
   "editor.insertSpaces": true,
   "editor.minimap.renderCharacters": false,


### PR DESCRIPTION
Prior to this change, the default font size was 12.

This change increases it to 13 to make it more ergonomic.
