### PR TITLE
[Homebrew] Do not check dependents on update

### DIFF
--- a/qaz/managers/brew.py
+++ b/qaz/managers/brew.py
@@ -5,7 +5,10 @@ from . import shell
 
 def install_or_upgrade_formula(formula: str) -> None:
     if formula.split("/")[-1] in _installed_formulae():
-        shell.run(f"brew upgrade {formula}")
+        shell.run(
+            f"brew upgrade {formula}",
+            env={"HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK": "1"},
+        )
     else:
         shell.run(f"brew install {formula}")
 


### PR DESCRIPTION
This speeds up installing/upgrading stuff, especially when they involve
Python (which sometimes tries to install a new version, which takes
ages).
