### PR TITLE
[GitHub] Use current branch to create new pull request

### DIFF
--- a/zshrc/github.zsh
+++ b/zshrc/github.zsh
@@ -12,6 +12,14 @@ alias grf=': \
   && git branch \
   && :'
 
+# Create a new PR in the origin repo
+function newpr() {
+  currentBranch=$(git branch --show-current)
+
+  git push --set-upstream origin $currentBranch
+  gh pr create --fill --web --head $currentBranch
+}
+
 alias gh-merged='\
   gh pr list \
   --author=@me --state=merged \


### PR DESCRIPTION
Prior to this change, we had to select where to push the branch to
create the new PR. This was tedious.

This change gets rid of that manual step by adding a new alias.
