### PR TITLE
[macOS] Update `ssh-add` flags

### DIFF
--- a/zshrc/_zsh.zsh
+++ b/zshrc/_zsh.zsh
@@ -8,7 +8,7 @@ alias la='ls -lAh'
 # Pipe my public key to my clipboard
 alias pubkey="more ~/.ssh/id_rsa.pub | pbcopy | echo '=> Public key copied to pasteboard.'"
 # Add my public key to keychain
-alias addkey="ssh-add -K ~/.ssh/id_rsa"
+alias addkey="ssh-add --apple-use-keychain ~/.ssh/id_rsa"
 
 # Set editor
 if [ -x "$(command -v code)" ]; then


### PR DESCRIPTION
Prior to this change, the `-K` option was deprecated.

This change updates the alias to use the new option name.
