### PR TITLE
Fix import formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,7 @@ repos:
     rev: "5.10.1"
     hooks:
       - id: isort
+        args: ['--settings-path', 'setup.cfg']
   - repo: https://github.com/psf/black
     rev: 22.1.0
     hooks:

--- a/configfiles/pythonstartup.py
+++ b/configfiles/pythonstartup.py
@@ -6,6 +6,7 @@
 # Always have pp available
 from pprint import pprint as pp
 
+
 # Import rich (https://rich.readthedocs.io/en/latest/introduction.html) to get prettier
 # output in the REPL.
 try:

--- a/qaz/application/git.py
+++ b/qaz/application/git.py
@@ -7,6 +7,7 @@ from qaz.modules import queries as module_queries
 
 from . import install
 
+
 logger = logging.getLogger(__name__)
 
 LOCAL_CONFIG_TEMPL = """

--- a/qaz/application/install.py
+++ b/qaz/application/install.py
@@ -9,6 +9,7 @@ from qaz.managers import files
 from qaz.modules import queries as module_queries
 from qaz.modules.base import Module
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/qaz/application/upgrade.py
+++ b/qaz/application/upgrade.py
@@ -9,6 +9,7 @@ from qaz.modules.base import Module
 
 from . import install
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/qaz/cli/_cli.py
+++ b/qaz/cli/_cli.py
@@ -4,10 +4,12 @@ import logging
 from collections.abc import Iterable
 
 import click
+
 from qaz.application import git, install, setup, update, upgrade
 
 from . import _list as list_modules
 from . import _logging
+
 
 logger = logging.getLogger(__name__)
 

--- a/qaz/cli/_list.py
+++ b/qaz/cli/_list.py
@@ -1,10 +1,11 @@
 import humanize
-from qaz.modules import base as modules_base
-from qaz.modules import queries as module_queries
-from qaz.modules.registry import registry as all_modules
 from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
+
+from qaz.modules import base as modules_base
+from qaz.modules import queries as module_queries
+from qaz.modules.registry import registry as all_modules
 
 
 def output_modules_lists() -> None:

--- a/qaz/managers/files.py
+++ b/qaz/managers/files.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 from . import shell
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/qaz/managers/shell.py
+++ b/qaz/managers/shell.py
@@ -6,6 +6,7 @@ import subprocess
 
 from qaz import settings
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/qaz/modules/registry.py
+++ b/qaz/modules/registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from .base import Module
 
+
 registry = {}
 
 

--- a/qaz/settings.py
+++ b/qaz/settings.py
@@ -6,6 +6,7 @@ import logging
 from pathlib import Path
 from typing import TypedDict
 
+
 logger = logging.getLogger(__name__)
 
 

--- a/qaz_modules/fonts.py
+++ b/qaz_modules/fonts.py
@@ -8,6 +8,7 @@ from qaz.managers import git, shell
 from qaz.modules.base import Module
 from qaz.modules.registry import register
 
+
 logger = logging.getLogger(__name__)
 
 FONTS = ["Hack"]

--- a/qaz_modules/vscode.py
+++ b/qaz_modules/vscode.py
@@ -4,6 +4,7 @@ from qaz.managers import vs_code
 from qaz.modules.base import Module
 from qaz.modules.registry import register
 
+
 if platform == "darwin":
     SETTINGS_DIR = "~/Library/Application Support/Code/User"
 elif platform == "linux":


### PR DESCRIPTION
Prior to this change, pre-commit started messing up the import sorting
with isort. It appears to have been picking up the configuration from
`configfiles/.editorconfig` instead of `setup.cfg`.

It appears that this is related to https://github.com/PyCQA/isort/issues/1872 and
https://github.com/PyCQA/isort/issues/1907.

This change explicitly sets the settings file to ensure the right file
is used.

We also fix the incorrect imports.