### PR TITLE
Stash local changes to qaz before updating

### DIFF
--- a/qaz/application/_update.py
+++ b/qaz/application/_update.py
@@ -10,7 +10,7 @@ def update() -> None:
     for this tool.
     """
     root_dir = settings.root_dir()
-    git.pull(root_dir)
+    git.pull(root_dir, with_stash=True)
     shell.run(f"{root_dir}/.venv/bin/python -m pip install --upgrade pip")
     shell.run(f"{root_dir}/.venv/bin/python -m pip install {root_dir}")
 

--- a/qaz/managers/git.py
+++ b/qaz/managers/git.py
@@ -9,8 +9,14 @@ def clone(*, repo_url: str, repo_path: Path | str, options: str = "") -> None:
     shell.run(f"git clone {options} {repo_url} {repo_path}")
 
 
-def pull(repo_path: Path | str) -> None:
+def pull(repo_path: Path | str, with_stash: bool = False) -> None:
+    if with_stash:
+        shell.run(f"git -C {repo_path} stash push")
+
     shell.run(f"git -C {repo_path} pull")
+
+    if with_stash:
+        shell.run(f"git -C {repo_path} stash pop")
 
 
 def version(repo_path: Path | str) -> str:


### PR DESCRIPTION
Prior to this change, if there were local changes, `update` would crash
because it couldn't pull the latest version.

This change stashes any local changes before pulling.

This isn't perfect but will solve most crashes (which are usually caused
by VS Code settings).
