### PR TITLE
[starship] Change prompt character to `$`

### DIFF
--- a/configfiles/starship.toml
+++ b/configfiles/starship.toml
@@ -11,6 +11,10 @@ $jobs$battery$shell\
 $character\
 """
 
+[character]
+success_symbol = '[\$](bold green)'
+error_symbol = '[\$](bold red)'
+
 [git_status]
 ahead = "⇡${count}"
 diverged = "⇡${ahead_count}⇣${behind_count}"


### PR DESCRIPTION
I often copy/paste shell snippets to share and this is a more commonly
understood prompt character.
