### PR TITLE
[git] Auto setup remote on push

### DIFF
--- a/configfiles/.gitconfig
+++ b/configfiles/.gitconfig
@@ -54,6 +54,7 @@
     rebase = true
 
 [push]
+    autoSetupRemote = true
     default = simple
 
 [rebase]


### PR DESCRIPTION
This allows us to do:

    git push

instead of

    git push --set-upstream origin HEAD
