### PR TITLE
Remove alias to 'e'

### DIFF
--- a/zshrc/_zsh.zsh
+++ b/zshrc/_zsh.zsh
@@ -27,8 +27,6 @@ if [ -x "$(command -v vim)" ]; then
   export VISUAL=vim
 fi
 
-alias e='$EDITOR'
-
 # Set pager options
 # -X is needed to fix a bug with the --quit-if-one-screen feature in old versions of less.
 # Unfortunately, it also breaks mouse-wheel support in less.


### PR DESCRIPTION
Prior to this change, I trained myself out of using this shortcut.

This change removes it.
