### PR TITLE
Fix module registry mutating classes

### DIFF
--- a/qaz/modules/registry.py
+++ b/qaz/modules/registry.py
@@ -15,7 +15,7 @@ class Registry:
             if module.is_installed:
                 yield module
 
-    def register(self, cls: type[ModuleBase]) -> ModuleBase:
+    def register(self, cls: type[ModuleBase]) -> type[ModuleBase]:
         assert (
             cls.name not in self.modules
         ), f"Module with name '{cls.name}' is already registered"
@@ -23,7 +23,7 @@ class Registry:
         module = cls()
         self.modules[cls.name.casefold()] = module
 
-        return module
+        return cls
 
     def populate(self) -> None:
         """Populate the registry."""


### PR DESCRIPTION
Prior to this change, the registry replaces the class with an instance
of itself.

This change makes the register method return the class that was passed
in.
